### PR TITLE
fix: preserve symlinks in macOS bundle zip

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -464,7 +464,21 @@ jobs:
         run: |
           python -m pytest tests/test_launcher.py -v
 
-      # Tier 5 (VSCodium GUI) is skipped on macOS: the .app bundle's
-      # framework symlinks are not preserved through zip/unzip, causing
-      # dyld errors.  Tiers 1-4 cover lean, lake, LSP, and launcher.
-      # TODO: preserve symlinks in create_zip for macOS bundles
+      # --- Tier 5: VSCodium integration smoke test ---
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 18
+
+      - name: "Tier 5: Install GUI test deps"
+        run: |
+          cd tests/gui
+          npm ci
+          npx tsc
+
+      - name: "Tier 5: VSCodium integration smoke test"
+        timeout-minutes: 8
+        env:
+          BUNDLE_ROOT: ${{ steps.find-root.outputs.BUNDLE_ROOT }}
+        run: |
+          cd tests/gui
+          node out/run-tests.js

--- a/PLAN.md
+++ b/PLAN.md
@@ -13,12 +13,6 @@
   equivalent to Linux's `unshare -rn`. The offline guarantee is proven on
   Linux; macOS tests run Tiers 1–4 without network isolation.
 
-- **macOS Tier 5 (VSCodium GUI).** The `.app` bundle's framework
-  symlinks are not preserved through Python's `zipfile` round-trip,
-  causing `dyld` errors when launching Electron. Need to preserve
-  symlinks in `create_zip` (e.g. use `ditto` on macOS or store
-  symlinks in the zip).
-
 ## Upstream changes that would simplify the bundle
 
 - **Lake offline mode**

--- a/bundle.py
+++ b/bundle.py
@@ -75,13 +75,18 @@ def create_zip(bundle_dir: Path, output_path: Path) -> None:
     print(f"Creating {output_path}...")
     with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
         for path in sorted(bundle_dir.rglob("*")):
-            if path.is_file():
-                arcname = str(path.relative_to(bundle_dir.parent))
+            arcname = str(path.relative_to(bundle_dir.parent))
+            if path.is_symlink():
+                # Store symlinks with the Unix symlink type flag
+                info = zipfile.ZipInfo(arcname)
+                info.external_attr = (0o120755 << 16)  # S_IFLNK | 0755
+                info.compress_type = zipfile.ZIP_STORED
+                zf.writestr(info, str(os.readlink(path)))
+            elif path.is_file():
                 info = zipfile.ZipInfo(arcname)
                 # Preserve Unix permissions (especially +x on binaries)
                 info.external_attr = (path.stat().st_mode & 0xFFFF) << 16
                 info.compress_type = zipfile.ZIP_DEFLATED
-                info.file_size = path.stat().st_size
                 with open(path, "rb") as f:
                     zf.writestr(info, f.read())
 

--- a/download.py
+++ b/download.py
@@ -63,12 +63,39 @@ def _sha256_file(path: Path) -> str:
 
 
 def _safe_extract_zip(zf: zipfile.ZipFile, dest: Path) -> None:
-    """Extract a zip file, rejecting entries that would escape dest."""
+    """Extract a zip file, preserving symlinks and rejecting path traversal."""
     dest = dest.resolve()
     for info in zf.infolist():
-        if not (dest / info.filename).resolve().is_relative_to(dest):
+        target = (dest / info.filename).resolve()
+        if not target.is_relative_to(dest):
             raise ValueError(f"Zip entry would extract outside {dest}: {info.filename!r}")
-    zf.extractall(dest)
+
+    for info in zf.infolist():
+        out_path = dest / info.filename
+        # Check if this entry is a Unix symlink (mode & S_IFLNK)
+        unix_mode = info.external_attr >> 16
+        if (unix_mode & 0o170000) == 0o120000:
+            # Symlink: the file data is the link target
+            link_target = zf.read(info.filename).decode("utf-8")
+            # Validate the resolved symlink stays inside dest
+            resolved = (out_path.parent / link_target).resolve()
+            if not resolved.is_relative_to(dest):
+                raise ValueError(
+                    f"Symlink would point outside {dest}: {info.filename!r} -> {link_target!r}"
+                )
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            if out_path.exists() or out_path.is_symlink():
+                out_path.unlink()
+            out_path.symlink_to(link_target)
+        elif info.is_dir():
+            out_path.mkdir(parents=True, exist_ok=True)
+        else:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as src, open(out_path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            # Restore Unix permissions if stored
+            if unix_mode:
+                out_path.chmod(unix_mode & 0o777)
 
 
 def _safe_extract_tar(tf: tarfile.TarFile, dest: Path) -> None:


### PR DESCRIPTION
## Summary

- Fix: macOS bundles were broken because Python's `zipfile.extractall()` silently converts symlinks to regular files, destroying the Electron framework structure in VSCodium.app
- `_safe_extract_zip` now properly extracts symlinks from zip files
- `create_zip` now stores symlinks as symlink entries (with `S_IFLNK` flag) instead of following them
- Re-enables Tier 5 (VSCodium GUI) test on macOS

Without this fix, macOS bundles crash on launch with `dyld: Library not loaded: @rpath/Electron Framework.framework/Electron Framework`.

## Test plan

- [ ] All existing tests pass (unit-tests, build-*, test-*)
- [ ] test-macos Tier 5 passes (VSCodium actually launches)

🤖 Prepared with Claude Code