### PR TITLE
Rename windows-x64 platform key to windows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           python bundle.py "$REPO_URL" \
             --project-dir /tmp/project \
-            --platform windows-x64 \
+            --platform windows \
             --work-dir /tmp/bundle-work \
             --output /tmp/bundle.zip
 
@@ -93,7 +93,7 @@ jobs:
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: bundle-windows-x64
+          name: bundle-windows
           path: /tmp/bundle.zip
           retention-days: 7
 
@@ -303,7 +303,7 @@ jobs:
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: bundle-windows-x64
+          name: bundle-windows
 
       - name: Extract bundle
         run: Expand-Archive -Path bundle.zip -DestinationPath bundle
@@ -326,7 +326,7 @@ jobs:
       - name: "Tier 1: Verify bundle structure"
         shell: pwsh
         run: |
-          python tests/verify_bundle.py "${{ steps.find-root.outputs.BUNDLE_ROOT }}" --platform windows-x64
+          python tests/verify_bundle.py "${{ steps.find-root.outputs.BUNDLE_ROOT }}" --platform windows
 
       # --- Existing: lean binary test ---
       - name: Test lean binary
@@ -713,7 +713,7 @@ jobs:
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: bundle-windows-x64
+          name: bundle-windows
 
       - name: Extract bundle
         run: Expand-Archive -Path bundle.zip -DestinationPath bundle

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ screenshots to [GitHub Pages](https://leanprover-community.github.io/bundle/).
 ## Usage
 
 ```bash
-python bundle.py https://github.com/PatrickMassot/MDD154 --platform windows-x64
+python bundle.py https://github.com/PatrickMassot/MDD154 --platform windows
 ```
 
-This produces `MDD154-bundle-windows-x64.zip` containing:
+This produces `MDD154-bundle-windows.zip` containing:
 
 - **VSCodium** (portable mode) with the lean4 extension pre-installed
 - **Lean 4** toolchain (trimmed to essentials)
@@ -60,7 +60,7 @@ Students need none of these.
 ### Options
 
 ```
---platform {windows-x64,linux-x64,darwin-x64,darwin-arm64}
+--platform {windows,linux-x64,darwin-x64,darwin-arm64}
     Target platform (default: auto-detect)
 
 --output PATH
@@ -89,7 +89,7 @@ If you've already cloned and built the project:
 ```bash
 python bundle.py https://github.com/PatrickMassot/MDD154 \
     --project-dir /path/to/MDD154 \
-    --platform windows-x64
+    --platform windows
 ```
 
 ## What's in the bundle

--- a/bundle.py
+++ b/bundle.py
@@ -2,7 +2,7 @@
 """Create a self-contained Lean 4 bundle for offline use.
 
 Usage:
-    python bundle.py https://github.com/PatrickMassot/MDD154 --platform windows-x64
+    python bundle.py https://github.com/PatrickMassot/MDD154 --platform windows
 
 This will:
 1. Clone the project
@@ -159,7 +159,7 @@ def main() -> None:
         machine = platform.machine().lower()
         system = platform.system().lower()
         if system == "windows":
-            args.platform = "windows-x64"
+            args.platform = "windows"
         elif system == "linux":
             args.platform = "linux-x64"
         elif system == "darwin":

--- a/download.py
+++ b/download.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 
 PLATFORM_MAP = {
-    "windows-x64": {
+    "windows": {
         "lean_suffix": "windows",
         "vscodium_asset_pattern": "VSCodium-win32-x64-{version}.zip",
         "vscodium_extract": "zip",

--- a/tests/verify_bundle.py
+++ b/tests/verify_bundle.py
@@ -5,7 +5,7 @@ Checks that all expected files, directories, DLLs, extensions, settings,
 and git stubs are present and correct.
 
 Usage:
-    python tests/verify_bundle.py <bundle_root> [--platform windows-x64]
+    python tests/verify_bundle.py <bundle_root> [--platform windows]
 """
 
 import json
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 
 
-def verify(bundle_root: Path, platform: str = "windows-x64") -> list[str]:
+def verify(bundle_root: Path, platform: str = "windows") -> list[str]:
     """Verify bundle structure. Returns list of error strings (empty = OK)."""
     errors: list[str] = []
     is_windows = platform.startswith("windows")
@@ -130,11 +130,11 @@ def verify(bundle_root: Path, platform: str = "windows-x64") -> list[str]:
 
 def main():
     if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <bundle_root> [--platform windows-x64]")
+        print(f"Usage: {sys.argv[0]} <bundle_root> [--platform windows]")
         sys.exit(1)
 
     bundle_root = Path(sys.argv[1])
-    platform = "windows-x64"
+    platform = "windows"
     if "--platform" in sys.argv:
         idx = sys.argv.index("--platform")
         if idx + 1 < len(sys.argv):


### PR DESCRIPTION
Lean 4 doesn't ship a Windows ARM64 build, and Windows-on-ARM has built-in x64 emulation, so the same bundle works on both. Drop the arch suffix to reflect that.

The other platform keys keep their arch suffix:
- `linux-arm64` will need its own bundle (Linux ARM has no built-in x64 emulation, unlike Windows-on-ARM) — see follow-up issue
- `darwin-x64` and `darwin-arm64` are already two separate bundles

Mechanical rename across `download.py`, `bundle.py`, `tests/verify_bundle.py`, `README.md`, and the GitHub Actions workflow. The CI artifact is also renamed `bundle-windows-x64` → `bundle-windows`.

🤖 Prepared with Claude Code