### PR TITLE
docs: close out .trace file investigation (#16)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -15,7 +15,14 @@
 ## Bundle size optimization
 
 - Investigate whether `.ir` files can be omitted (saves ~30% of olean size)
-- Investigate `.trace` file necessity
+- ~~Investigate `.trace` file necessity~~ — **not worth doing**
+  ([#16](https://github.com/leanprover-community/bundle/issues/16)).
+  Measurement on an MDD154 build: 7,803 `.trace` files, **2.09 MB total**
+  (≈0.08% of the bundle). Deleting them does not just leave targets
+  "stale" — `lake setup-file` immediately starts an 893-module rebuild
+  instead of returning the import artifact JSON. The size win is
+  negligible and the failure mode is the exact broken-infoview scenario
+  [`test_lake_setup_file_offline`](tests/test_offline.py) guards against.
 - **Git shim instead of MinGit (Windows, saves ~46 MB).** The lean4 VS Code
   extension checks for `git` on PATH at startup and blocks the language server
   if it's missing. But Lake's git operations are already neutralized by


### PR DESCRIPTION
## Summary

Resolves https://github.com/leanprover-community/bundle/issues/16 as "not worth doing" and updates `PLAN.md` so we stop revisiting it.

**Measurement** (MDD154 bundle source dir built against mathlib):

- **7,803 `.trace` files, 2.09 MB total** (~0.08% of the bundle).
- Breakdown: `build/lib/` 7,789 files (2.17 MB), `build/ir/` 8 files (11 KB), `build/js/` 1 file (7.8 KB), `build/bin/` 1 file (3.7 KB), `.lake/` root 4 files (1.3 KB).
- Comfortably under the issue's own "<5 MB out of ~250 MB → probably close" threshold.

**Experiment.** Copied the source project, ran `assemble.rewrite_deps_to_path` and the olean timestamp touch, then `lake setup-file` on `Mdd154/exos/e1_recurrence.lean`:

1. Baseline (traces present): exit 0, 0.96s, no "Building" output — just the 413 KB `importArts` JSON.
2. Delete all `.trace` files, re-run: Lake immediately starts rebuilding. Killed after ~40s at `✔ [833/893] Built Mathlib.Order.Bounds.OrderIso`.

So Lake does **not** skip trace validation when traces are absent — it treats absent-as-dirty and kicks off a full rebuild. That is exactly the broken-infoview scenario [`test_lake_setup_file_offline`](tests/test_offline.py) guards against, and the ~2 MB size win does not justify the risk.

No code change: [`assemble.py`](assemble.py) already copies the full `.lake` tree for this reason and the regression test already enforces it. This PR just strikes the bullet in `PLAN.md`.

Measurement comment also posted on the issue for the record.

## Test plan

- [ ] CI green (doc-only change)

🤖 Prepared with Claude Code