### PR TITLE
Replace MinGit with a tiny git.exe shim on Windows (~46 MB saved)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,6 +78,11 @@ jobs:
           curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.1/elan-init.sh | sh -s -- -y --default-toolchain none
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
+      - name: Install mingw-w64 (for git.exe shim cross-build)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64
+
       - name: Build Windows bundle
         run: |
           python bundle.py "$REPO_URL" \

--- a/PLAN.md
+++ b/PLAN.md
@@ -10,7 +10,12 @@
 
 - **Extension git check suppression**
   ([Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/trylean.20bundle.20for.20lean4/near/581773347)).
-  Would let us drop MinGit (~46MB) from the bundle entirely.
+  Would let us retire the Windows `git.exe` shim (`shim/git_shim.c`). Note
+  that VS Code's built-in git extension *also* probes `git --version` and
+  `git rev-parse --show-toplevel` at workspace activation, so even after
+  the lean4 extension stops probing, the shim (or an explicit
+  `"git.enabled": false` in `settings.json`) is still needed to keep the
+  SCM sidebar quiet.
 
 ## Bundle size optimization
 
@@ -23,13 +28,3 @@
   instead of returning the import artifact JSON. The size win is
   negligible and the failure mode is the exact broken-infoview scenario
   [`test_lake_setup_file_offline`](tests/test_offline.py) guards against.
-- **Git shim instead of MinGit (Windows, saves ~46 MB).** The lean4 VS Code
-  extension checks for `git` on PATH at startup and blocks the language server
-  if it's missing. But Lake's git operations are already neutralized by
-  rewriting manifests to path deps, so no real git functionality is needed at
-  runtime. A tiny shim binary (a few KB) that responds to the extension's
-  probe commands (`git --version`, `git rev-parse`, etc.) with plausible
-  canned responses could replace the full 46 MB MinGit. This is roughly a
-  **15–20% reduction** in total bundle size (MinGit is ~46 MB out of a
-  ~250–300 MB bundle). Unlike the upstream suppression approach, this
-  requires no extension changes and can be implemented immediately.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ This produces `MDD154-bundle-windows.zip` containing:
 
 - **VSCodium** (portable mode) with the lean4 extension pre-installed
 - **Lean 4** toolchain (trimmed to essentials)
-- **MinGit** (minimal git for Windows, needed by the lean4 extension)
+- A tiny **`git.exe` shim** (~10 KB) to satisfy the lean4 and built-in
+  git extensions' startup probes without shipping a full git install
 - The **project source files**
 - **Only the oleans transitively needed** by the project (not all of Mathlib)
 
@@ -57,6 +58,10 @@ This produces `MDD154-bundle-windows.zip` containing:
 - [elan](https://github.com/leanprover/elan) with the project's Lean toolchain
 - Lean 4.17+ (for `lean --src-deps`)
 - Network access (to download components and mathlib cache)
+- A C compiler able to produce 64-bit Windows PE binaries **when
+  building Windows bundles** (mingw-w64 is recommended;
+  `apt-get install gcc-mingw-w64-x86-64` on Debian/Ubuntu). Zig or native
+  `gcc`/`clang` on a Windows build host also work.
 
 Students need none of these.
 
@@ -139,12 +144,19 @@ python bundle.py https://github.com/PatrickMassot/MDD154 --platform linux-x64 --
 
 ## Known issues
 
-- **MinGit is bundled as a workaround.** The lean4 VS Code extension checks
-  for git at startup and blocks the language server if it's missing. We bundle
-  MinGit (~46MB) to satisfy this check, even though the bundle doesn't need git
-  at runtime. This can be removed once the extension provides a way to suppress
-  the dependency check
-  ([Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/trylean.20bundle.20for.20lean4/near/581773347)).
+- **Git shim on Windows.** The lean4 VS Code extension and VS Code's
+  built-in git extension both probe for `git` on PATH at startup. Rather
+  than shipping the full 46 MB MinGit distribution, the bundle includes a
+  ~10 KB C shim at `git/cmd/git.exe` that answers only the two probes
+  both extensions make at activation: `git --version` (returns
+  `git version 2.47.0`) and `git rev-parse --show-toplevel` (returns
+  "not a git repository"). Lake's own git calls are optional fallbacks
+  (`captureProc?`/`testProc`) and also tolerate the shim's non-zero
+  exits. Source: `shim/git_shim.c`. This can be retired entirely once
+  the lean4 extension provides a way to suppress its git check
+  ([Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/trylean.20bundle.20for.20lean4/near/581773347))
+  *and* VS Code's built-in git extension is disabled via settings.json
+  — whichever probe comes last determines whether the shim stays.
 
 - **Dep rewriting for offline use.** We rewrite `lake-manifest.json` and
   `lakefile.toml`/`lakefile.lean` to convert git dependencies to path
@@ -158,7 +170,7 @@ Several component versions are hardcoded and need periodic bumps:
 
 | Component | Where | Notes |
 |-----------|-------|-------|
-| MinGit | `download.py` `MINGIT_VERSION` | Windows only |
+| git shim version string | `shim/git_shim.c` (`VERSION_LINE`) | Must be >= 2.0.0, not 2.25.x/2.26.x |
 | even-better-toml extension | `download.py` `ALLOWED_EXTENSION_DEPS` | ID + version |
 | elan installer | `.github/workflows/build-and-test.yml` | Tag in curl URL |
 | GitHub Actions (checkout, setup-python, etc.) | `.github/workflows/build-and-test.yml` | Pinned by commit SHA |

--- a/assemble.py
+++ b/assemble.py
@@ -467,7 +467,7 @@ def assemble_bundle(
     lean_dir: Path,
     vscodium_dir: Path,
     extension_dirs: list[Path],
-    mingit_dir: Path | None,
+    git_shim_exe: Path | None,
     templates_dir: Path,
     bundle_dir: Path,
     platform: str,
@@ -480,7 +480,8 @@ def assemble_bundle(
         lean_dir: Extracted and trimmed lean toolchain directory.
         vscodium_dir: Extracted VSCodium directory.
         extension_dirs: Extracted extension directories (lean4 + dependencies).
-        mingit_dir: Extracted MinGit directory (Windows only, None on other platforms).
+        git_shim_exe: Path to the built git.exe shim (Windows only, None
+            on other platforms).
         templates_dir: Directory containing launcher and settings templates.
         bundle_dir: Output bundle directory to create.
         platform: Target platform key.
@@ -490,9 +491,15 @@ def assemble_bundle(
     print("Copying lean toolchain...")
     shutil.copytree(lean_dir, bundle_dir / "lean", symlinks=True, dirs_exist_ok=True)
 
-    if mingit_dir is not None:
-        print("Copying MinGit...")
-        shutil.copytree(mingit_dir, bundle_dir / "git", symlinks=True, dirs_exist_ok=True)
+    if git_shim_exe is not None:
+        # Place the shim at <bundle>/git/cmd/git.exe so start_lean.cmd can
+        # continue prepending "%BUNDLE_ROOT%\git\cmd" to PATH. The layout
+        # matches the old MinGit install, which keeps the launcher script
+        # and any muscle-memory docs working.
+        print("Installing git shim...")
+        git_cmd = bundle_dir / "git" / "cmd"
+        git_cmd.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(git_shim_exe, git_cmd / "git.exe")
 
     print("Setting up VSCodium...")
     shutil.copytree(vscodium_dir, bundle_dir / "vscodium", symlinks=True, dirs_exist_ok=True)

--- a/bundle.py
+++ b/bundle.py
@@ -28,9 +28,9 @@ from pathlib import Path
 from assemble import assemble_bundle
 from download import (
     PLATFORM_MAP,
+    build_git_shim,
     download_lean4_extension,
     download_lean_toolchain,
-    download_mingit,
     download_vscodium,
     parse_toolchain,
     trim_lean_toolchain,
@@ -196,7 +196,7 @@ def main() -> None:
         lean_dir = download_lean_toolchain(lean_version, args.platform, downloads_dir)
         vscodium_dir, vscodium_version = download_vscodium(args.platform, downloads_dir, args.vscodium_version)
         extension_dirs, extension_version = download_lean4_extension(downloads_dir, args.extension_version)
-        mingit_dir = download_mingit(downloads_dir, args.platform)
+        git_shim_exe = build_git_shim(downloads_dir, args.platform)
 
         if not args.project_dir:
             print("\n--- Building project ---")
@@ -212,7 +212,7 @@ def main() -> None:
             lean_dir=lean_dir,
             vscodium_dir=vscodium_dir,
             extension_dirs=extension_dirs,
-            mingit_dir=mingit_dir,
+            git_shim_exe=git_shim_exe,
             templates_dir=templates_dir,
             bundle_dir=bundle_dir,
             platform=args.platform,

--- a/download.py
+++ b/download.py
@@ -47,11 +47,23 @@ PLATFORM_MAP = {
 }
 
 
-MINGIT_VERSION = "2.47.1.2"
-MINGIT_SHA256 = "5bafb35dfb249b89d726b37824eeb5022379f0e51f5fbf9c29f49bef57e85b42"
-# Git for Windows tags: vMAJOR.MINOR.PATCH.windows.REV
-_mingit_base, _mingit_rev = MINGIT_VERSION.rsplit(".", 1)
-MINGIT_URL = f"https://github.com/git-for-windows/git/releases/download/v{_mingit_base}.windows.{_mingit_rev}/MinGit-{MINGIT_VERSION}-64-bit.zip"
+# Candidate C compilers that can produce a 64-bit Windows PE. Each entry is
+# ``(binary, extra_args, cross_only)`` — ``cross_only`` binaries are explicit
+# cross-compilers and are always safe. Non-``cross_only`` entries are native
+# compilers that are only safe when we are already running on Windows (where
+# ``gcc``/``clang`` produce PE binaries without extra flags). Running
+# ``bundle.py --platform windows`` on Linux/macOS without mingw or zig
+# would otherwise silently produce an ELF/Mach-O file named ``git.exe``.
+_GIT_SHIM_COMPILERS: tuple[tuple[str, tuple[str, ...], bool], ...] = (
+    # Explicit cross-compilers — always safe.
+    ("x86_64-w64-mingw32-gcc", (), True),
+    ("x86_64-w64-mingw32-cc", (), True),
+    # Zig's cc driver ships its own libc and cross-compiles trivially.
+    ("zig", ("cc", "-target", "x86_64-windows-gnu"), True),
+    # Native compilers — only trusted on a Windows build host.
+    ("gcc", (), False),
+    ("clang", (), False),
+)
 
 # Extension dependencies expected from the lean4 extension's package.json.
 # Maps extension ID to pinned version. Reject unknown IDs and fetch only the
@@ -129,37 +141,106 @@ def _safe_extract_tar(tf: tarfile.TarFile, dest: Path) -> None:
     tf.extractall(dest)
 
 
-def download_mingit(dest_dir: Path, platform: str) -> Path | None:
-    """Download MinGit for Windows. Returns None on non-Windows platforms.
+def build_git_shim(dest_dir: Path, platform: str) -> Path | None:
+    """Build a tiny ``git.exe`` shim for Windows bundles.
 
-    The lean4 VS Code extension requires git on PATH. Students may not
-    have git installed, so we bundle MinGit.
+    The lean4 VS Code extension and VS Code's built-in git extension both
+    probe for ``git`` on PATH at startup. Historically the bundle shipped
+    MinGit (~46 MB) to satisfy this probe. The shim is a ~30 KB C program
+    that answers only the probes both extensions perform at activation
+    (see ``shim/git_shim.c`` for the full probe surface).
+
+    Returns the path to the built ``git.exe``, or ``None`` on non-Windows
+    platforms. Raises ``RuntimeError`` if no suitable compiler is found;
+    on Linux, install ``gcc-mingw-w64-x86-64`` or put ``zig`` on PATH.
+    Raises ``RuntimeError`` (with the offending bytes) if the compiler
+    produced something that isn't a Windows PE image — this guards
+    against accidentally building with a native compiler that doesn't
+    cross-compile (e.g. clang on macOS without ``-target``).
     """
     if not platform.startswith("windows"):
         return None
 
-    mingit_dir = dest_dir / "mingit"
-    if mingit_dir.is_dir():
-        return mingit_dir
+    source = Path(__file__).resolve().parent / "shim" / "git_shim.c"
+    if not source.is_file():
+        raise RuntimeError(f"git shim source not found: {source}")
 
-    archive = dest_dir / f"MinGit-{MINGIT_VERSION}-64-bit.zip"
-    print(f"  Downloading MinGit {MINGIT_VERSION}...")
-    _download(MINGIT_URL, archive)
-    actual = _sha256_file(archive)
-    print(f"  SHA-256: {actual}")
-    if actual != MINGIT_SHA256:
-        archive.unlink()
-        raise ValueError(
-            f"MinGit checksum mismatch: expected {MINGIT_SHA256}, got {actual}"
+    shim_dir = dest_dir / "git-shim"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    output = shim_dir / "git.exe"
+    # Source is unlikely to change mid-build, but if someone edits the .c
+    # and reuses an existing work-dir we want the new shim, not a stale one.
+    if output.is_file() and output.stat().st_mtime >= source.stat().st_mtime:
+        _assert_pe_image(output)
+        return output
+
+    compiler, extra = _find_git_shim_compiler()
+    cmd = [compiler, *extra, "-O2", "-Wall", "-Wextra", "-s",
+           "-o", str(output), str(source)]
+    print(f"  Building git shim with {compiler}...")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git shim build failed ({' '.join(cmd)}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
+    _assert_pe_image(output)
+    size = output.stat().st_size
+    print(f"  Built {output.name} ({size} bytes)")
+    return output
 
-    print(f"  Extracting MinGit...")
-    mingit_dir.mkdir(exist_ok=True)
-    with zipfile.ZipFile(archive) as zf:
-        _safe_extract_zip(zf, mingit_dir)
-    archive.unlink()
 
-    return mingit_dir
+def _assert_pe_image(path: Path) -> None:
+    """Verify ``path`` is a Windows PE32+ image.
+
+    A PE file begins with a DOS header (``MZ``) followed by an optional
+    DOS stub; the real PE header lives at the 4-byte offset stored at
+    0x3C in the DOS header and starts with ``PE\\0\\0``. We check both so
+    an accidentally native-compiled ELF/Mach-O binary is caught loudly
+    instead of silently shipping a non-Windows file named ``git.exe``.
+    """
+    with open(path, "rb") as f:
+        dos = f.read(0x40)
+        if len(dos) < 0x40 or dos[:2] != b"MZ":
+            raise RuntimeError(
+                f"git shim at {path} is not a PE image (bad DOS magic): "
+                f"{dos[:4]!r}"
+            )
+        e_lfanew = int.from_bytes(dos[0x3C:0x40], "little")
+        f.seek(e_lfanew)
+        pe_sig = f.read(4)
+        if pe_sig != b"PE\x00\x00":
+            raise RuntimeError(
+                f"git shim at {path} is not a PE image "
+                f"(bad PE signature at 0x{e_lfanew:X}): {pe_sig!r}. "
+                f"A native non-Windows compiler probably built the shim. "
+                f"Install mingw-w64 (apt-get install gcc-mingw-w64-x86-64) "
+                f"or zig."
+            )
+
+
+def _find_git_shim_compiler() -> tuple[str, tuple[str, ...]]:
+    """Return ``(binary, extra_args)`` for the first available compiler.
+
+    On non-Windows build hosts, only explicit cross-compilers are
+    considered — a native ``gcc``/``clang`` on Linux/macOS would produce
+    an ELF/Mach-O binary rather than a PE image. Raises ``RuntimeError``
+    with install instructions if none is found.
+    """
+    on_windows = sys.platform == "win32"
+    for binary, extra, cross_only in _GIT_SHIM_COMPILERS:
+        if not cross_only and not on_windows:
+            continue
+        resolved = shutil.which(binary)
+        if resolved:
+            return resolved, extra
+    raise RuntimeError(
+        "No C compiler found for building the Windows git shim. Install "
+        "one of:\n"
+        "  - mingw-w64 (Linux: apt-get install gcc-mingw-w64-x86-64)\n"
+        "  - zig (https://ziglang.org/download/)\n"
+        "  - gcc or clang on a Windows build host"
+    )
 
 
 def parse_toolchain(toolchain_file: Path) -> str:

--- a/shim/git_shim.c
+++ b/shim/git_shim.c
@@ -1,0 +1,107 @@
+/*
+ * Tiny git.exe shim for the Lean 4 bundle.
+ *
+ * Purpose: the lean4 VS Code extension and VS Code's built-in `git` extension
+ * both probe for `git` on PATH at startup. Without git they refuse to activate
+ * (lean4) or log a missing-git warning and disable the SCM panel (built-in).
+ * Historically the bundle shipped MinGit (~46 MB) to satisfy this probe. This
+ * shim replaces MinGit with a <100 KB binary that answers exactly the probes
+ * both extensions perform at activation and no more.
+ *
+ * Probe surface (verified against vscode-lean4 v0.0.229 source and
+ * vscode/extensions/git source as of 2026-04):
+ *
+ *   lean4 extension (checkGitAvailable):
+ *     git --version            -> must exit 0
+ *
+ *   VS Code built-in git extension (findGit + initial repository scan):
+ *     git --version            -> must exit 0 AND print `git version X.Y.Z`
+ *                                 where X.Y.Z parses as >= 2.0.0 and is NOT
+ *                                 2.25.x or 2.26.x (both trigger modal
+ *                                 deprecation warnings on Windows).
+ *     git rev-parse --show-toplevel (per workspace folder and each direct
+ *                                 subfolder) -> exit non-zero with stderr
+ *                                 containing the phrase "Not a git repository"
+ *                                 so the folder is silently ignored as
+ *                                 non-git.
+ *
+ * Neither extension parses anything beyond exit code and version string, and
+ * the lake build tool wraps its optional git probes (Reservoir cache, release
+ * URL lookup) in `captureProc?` / `testProc` which ignore non-zero exits.
+ * So the shim can safely reply to every unrecognized subcommand with the
+ * "not a git repository" error shape.
+ *
+ * See issue #18 for the full discovery notes.
+ *
+ * Build:
+ *   x86_64-w64-mingw32-gcc -O2 -s -o git.exe git_shim.c   (cross on Linux)
+ *   gcc -O2 -s -o git.exe git_shim.c                      (native on Windows)
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+/* Must be >= 2.0.0 and must NOT be 2.25.x/2.26.x (VS Code pops a modal
+ * deprecation warning for those on Windows). Choosing 2.47.0 matches the
+ * MinGit version previously shipped with the bundle. */
+static const char VERSION_LINE[] = "git version 2.47.0\n";
+
+/* VS Code's git extension matches stderr against /Not a git repository/i
+ * (getGitErrorCode in extensions/git/src/git.ts). Any stderr containing
+ * that phrase tags the error as NotAGitRepository, which is silently
+ * swallowed by the model scanner. Real git exits 128 for this case. */
+static const char NOT_A_REPO[] =
+    "fatal: not a git repository (or any of the parent directories): .git\n";
+
+static int is_version_flag(const char *a) {
+    return strcmp(a, "--version") == 0
+        || strcmp(a, "-v") == 0;
+}
+
+/* A few top-level flags consume the next argv entry (e.g. `git -C <dir>
+ * rev-parse`). Skip over them when scanning for the subcommand so that a
+ * caller like `git -c user.name=foo commit` doesn't confuse us into thinking
+ * `user.name=foo` is the subcommand. */
+static int consumes_next(const char *a) {
+    return strcmp(a, "-C") == 0
+        || strcmp(a, "-c") == 0
+        || strcmp(a, "--git-dir") == 0
+        || strcmp(a, "--work-tree") == 0
+        || strcmp(a, "--namespace") == 0;
+}
+
+int main(int argc, char *argv[]) {
+    const char *sub = NULL;
+    int i = 1;
+
+    while (i < argc) {
+        const char *a = argv[i];
+        if (a[0] != '-') {
+            sub = a;
+            break;
+        }
+        if (is_version_flag(a)) {
+            fputs(VERSION_LINE, stdout);
+            return 0;
+        }
+        if (consumes_next(a)) {
+            i += 2;
+            continue;
+        }
+        /* Unknown top-level flag: skip it and keep scanning. */
+        i += 1;
+    }
+
+    if (sub != NULL && strcmp(sub, "version") == 0) {
+        fputs(VERSION_LINE, stdout);
+        return 0;
+    }
+
+    /* Any other invocation: pretend we're not inside a git repo. Both the
+     * lean4 extension and the VS Code git extension either ignore this or
+     * abort cleanly, and Lake's optional git probes (`captureProc?`,
+     * `testProc`) treat non-zero exit as "no result" without surfacing the
+     * error. The exit code (128) matches real git's "not a repository". */
+    fputs(NOT_A_REPO, stderr);
+    return 128;
+}

--- a/test.sh
+++ b/test.sh
@@ -42,7 +42,7 @@ cd "$SCRIPT_DIR"
 
 echo ""
 echo "=== Python unit tests ==="
-python3 -m pytest tests/test_assemble.py tests/test_import_closure.py -v || true
+python3 -m pytest tests/test_assemble.py tests/test_import_closure.py tests/test_git_shim.py -v || true
 
 echo ""
 echo "=== Tier 1: Bundle structure ==="

--- a/tests/test_git_shim.py
+++ b/tests/test_git_shim.py
@@ -1,0 +1,262 @@
+"""Tests for the tiny git.exe shim that replaces MinGit on Windows.
+
+These tests compile the C source with whatever native compiler is on PATH
+and run it directly. That covers the behavioural surface (correct exit
+codes, version string, stderr phrasing) independent of the Windows PE
+cross-build used in production. The production build itself is exercised
+end-to-end by the Tier 1 bundle verify check and the Tier 5/6 Playwright
+runs on Windows CI.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHIM_SOURCE = REPO_ROOT / "shim" / "git_shim.c"
+
+
+def _native_cc() -> str | None:
+    """First available native C compiler."""
+    for name in ("gcc", "clang", "cc"):
+        p = shutil.which(name)
+        if p:
+            return p
+    return None
+
+
+@pytest.fixture(scope="module")
+def shim_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build the shim once per test module with the native compiler."""
+    cc = _native_cc()
+    if cc is None:
+        pytest.skip("no native C compiler available")
+    if not SHIM_SOURCE.is_file():
+        pytest.fail(f"shim source missing: {SHIM_SOURCE}")
+
+    out_dir = tmp_path_factory.mktemp("shim")
+    exe_name = "git.exe" if sys.platform == "win32" else "git_shim"
+    out = out_dir / exe_name
+
+    result = subprocess.run(
+        [cc, "-O2", "-Wall", "-Wextra", "-o", str(out), str(SHIM_SOURCE)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"Failed to build shim with {cc}:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    if not out.is_file():
+        pytest.fail(f"shim binary not produced at {out}")
+    # Some filesystems drop the exec bit on write; make sure we can run it.
+    if sys.platform != "win32":
+        os.chmod(out, 0o755)
+    return out
+
+
+def _run(shim: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(shim), *args],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+class TestVersionProbe:
+    """The most important probe: the one both extensions gate activation on."""
+
+    def test_dash_dash_version_exits_zero(self, shim_binary: Path) -> None:
+        r = _run(shim_binary, "--version")
+        assert r.returncode == 0, f"stderr: {r.stderr}"
+
+    def test_dash_dash_version_prints_git_version(self, shim_binary: Path) -> None:
+        r = _run(shim_binary, "--version")
+        assert r.stdout.startswith("git version "), f"stdout: {r.stdout!r}"
+
+    def test_version_subcommand_exits_zero(self, shim_binary: Path) -> None:
+        """`git version` (no dashes) is a real alias and must behave."""
+        r = _run(shim_binary, "version")
+        assert r.returncode == 0
+        assert r.stdout.startswith("git version ")
+
+    def test_dash_v_exits_zero(self, shim_binary: Path) -> None:
+        r = _run(shim_binary, "-v")
+        assert r.returncode == 0
+        assert r.stdout.startswith("git version ")
+
+    def test_reported_version_is_modern(self, shim_binary: Path) -> None:
+        """VS Code's git extension pops a modal warning for git < 2 or
+        git == 2.25.x / 2.26.x. The shim must not trip either check."""
+        r = _run(shim_binary, "--version")
+        version = r.stdout.removeprefix("git version ").strip()
+        major_s, minor_s, *_ = version.split(".")
+        major = int(major_s)
+        minor = int(minor_s)
+        assert major >= 2, f"version {version} triggers git-v1 modal"
+        assert not (major == 2 and minor in (25, 26)), (
+            f"version {version} triggers the Windows 2.25/2.26 modal"
+        )
+
+
+class TestNotARepoProbe:
+    """VS Code's built-in git extension calls `rev-parse --show-toplevel`
+    on every workspace folder and expects non-zero + a /Not a git
+    repository/i stderr to treat the folder as a non-repo."""
+
+    def test_rev_parse_exits_nonzero(self, shim_binary: Path) -> None:
+        r = _run(shim_binary, "rev-parse", "--show-toplevel")
+        assert r.returncode != 0
+
+    def test_rev_parse_stderr_matches_git_error_code_regex(
+        self, shim_binary: Path
+    ) -> None:
+        """VS Code's getGitErrorCode maps stderr matching
+        /Not a git repository/i onto GitErrorCodes.NotAGitRepository."""
+        r = _run(shim_binary, "rev-parse", "--show-toplevel")
+        assert "not a git repository" in r.stderr.lower(), (
+            f"stderr does not match /Not a git repository/i: {r.stderr!r}"
+        )
+
+    def test_rev_parse_exit_code_128(self, shim_binary: Path) -> None:
+        """Real git returns 128 for "not a git repository"."""
+        r = _run(shim_binary, "rev-parse", "--show-toplevel")
+        assert r.returncode == 128
+
+    def test_toplevel_flag_c_is_consumed(self, shim_binary: Path) -> None:
+        """`git -C <dir> rev-parse` is common; the `-C <dir>` must not be
+        mistaken for the subcommand."""
+        r = _run(shim_binary, "-C", "/tmp", "rev-parse", "--show-toplevel")
+        assert r.returncode == 128
+        assert "not a git repository" in r.stderr.lower()
+
+    def test_toplevel_flag_c_config_is_consumed(self, shim_binary: Path) -> None:
+        """`git -c user.name=foo commit` — the `-c user.name=foo` must
+        not be mistaken for the subcommand."""
+        r = _run(
+            shim_binary,
+            "-c", "user.name=foo",
+            "-c", "user.email=",
+            "commit", "-m", "x",
+        )
+        assert r.returncode == 128
+        assert "not a git repository" in r.stderr.lower()
+
+    def test_dangling_dash_c_does_not_crash(self, shim_binary: Path) -> None:
+        """`git -C` with no following arg — the scanner must not read
+        past argc or dereference a nonexistent argv entry."""
+        r = _run(shim_binary, "-C")
+        assert r.returncode == 128
+        assert "not a git repository" in r.stderr.lower()
+
+    def test_bare_git_does_not_crash(self, shim_binary: Path) -> None:
+        """Bare `git` with no args is degenerate but must not crash."""
+        r = _run(shim_binary)
+        assert r.returncode == 128
+        assert "not a git repository" in r.stderr.lower()
+
+
+class TestUnknownSubcommands:
+    """Anything the shim doesn't explicitly handle must be safe to fail.
+    Both VS Code extensions and Lake wrap these in try/catch or `captureProc?`."""
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ("status", "--porcelain"),
+            ("rev-parse", "HEAD"),
+            ("rev-parse", "--verify", "--end-of-options", "HEAD"),
+            ("config", "--get", "user.name"),
+            ("remote", "get-url", "origin"),
+            ("describe", "--tags", "--exact-match", "HEAD"),
+            ("clone", "https://example.com/x", "/tmp/x"),
+            ("fetch", "--tags", "--force", "origin"),
+            ("checkout", "--detach", "abc123", "--"),
+            ("diff", "HEAD", "--exit-code"),
+        ],
+    )
+    def test_unknown_subcommand_exits_128(
+        self, shim_binary: Path, argv: tuple[str, ...]
+    ) -> None:
+        r = _run(shim_binary, *argv)
+        assert r.returncode == 128, (
+            f"`git {' '.join(argv)}` exited {r.returncode}, expected 128"
+        )
+
+
+def _have_cross_compiler() -> bool:
+    """True iff an explicit PE cross-compiler is on PATH."""
+    for name in ("x86_64-w64-mingw32-gcc", "x86_64-w64-mingw32-cc", "zig"):
+        if shutil.which(name):
+            return True
+    return False
+
+
+class TestBuildGitShim:
+    """Exercise the download.build_git_shim helper end-to-end."""
+
+    def test_returns_none_on_non_windows(self, tmp_path: Path) -> None:
+        from download import build_git_shim
+
+        assert build_git_shim(tmp_path, "linux-x64") is None
+        assert build_git_shim(tmp_path, "darwin-arm64") is None
+
+    def test_builds_for_windows(self, tmp_path: Path) -> None:
+        """Full build via ``build_git_shim`` — requires either a real PE
+        cross-compiler (mingw / zig) or a native Windows host. On
+        macOS/Linux without mingw or zig, the helper correctly refuses
+        to fall through to native gcc/clang."""
+        from download import build_git_shim
+
+        if not _have_cross_compiler() and sys.platform != "win32":
+            with pytest.raises(RuntimeError, match="No C compiler found"):
+                build_git_shim(tmp_path, "windows")
+            return
+
+        out = build_git_shim(tmp_path, "windows")
+        assert out is not None
+        assert out.is_file()
+        assert out.name == "git.exe"
+        assert out.stat().st_size > 0
+
+        # Must be a real PE image — not an ELF/Mach-O wearing a .exe hat.
+        with open(out, "rb") as f:
+            dos = f.read(0x40)
+        assert dos[:2] == b"MZ", f"not a PE (DOS magic): {dos[:4]!r}"
+        e_lfanew = int.from_bytes(dos[0x3C:0x40], "little")
+        with open(out, "rb") as f:
+            f.seek(e_lfanew)
+            sig = f.read(4)
+        assert sig == b"PE\x00\x00", f"not a PE (bad PE sig): {sig!r}"
+
+    def test_native_non_windows_compiler_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If someone removes the cross-only guard and a native compiler
+        produces an ELF/Mach-O binary, the PE signature check should
+        catch it loudly. Simulate that by patching
+        ``_find_git_shim_compiler`` to return a native compiler on a
+        non-Windows host."""
+        if sys.platform == "win32":
+            pytest.skip("native compiler on Windows produces valid PE")
+        cc = _native_cc()
+        if cc is None:
+            pytest.skip("no native compiler to misuse")
+
+        import download
+
+        monkeypatch.setattr(
+            download,
+            "_find_git_shim_compiler",
+            lambda: (cc, ()),
+        )
+        with pytest.raises(RuntimeError, match="not a PE image"):
+            download.build_git_shim(tmp_path, "windows")

--- a/tests/verify_bundle.py
+++ b/tests/verify_bundle.py
@@ -87,6 +87,41 @@ def verify(bundle_root: Path, platform: str = "windows") -> list[str]:
     if is_windows:
         if not (bundle_root / "lean" / "bin" / "libleanshared.dll").is_file():
             errors.append("Missing critical DLL: lean/bin/libleanshared.dll")
+
+        # git shim: must be at git/cmd/git.exe so the launcher's PATH entry
+        # resolves. We don't try to execute it here (Tier 1 runs on Linux too),
+        # but we verify it is a real Windows PE image: the DOS header must
+        # start with "MZ" and the PE header at the offset stored at 0x3C
+        # must begin with "PE\0\0". This catches native compilers that
+        # silently produce ELF/Mach-O binaries with a .exe name.
+        git_shim = bundle_root / "git" / "cmd" / "git.exe"
+        if not git_shim.is_file():
+            errors.append("Missing git shim: git/cmd/git.exe")
+        else:
+            with open(git_shim, "rb") as f:
+                dos = f.read(0x40)
+            if len(dos) < 0x40 or dos[:2] != b"MZ":
+                errors.append(
+                    f"git/cmd/git.exe is not a PE image (DOS magic: {dos[:4]!r})"
+                )
+            else:
+                e_lfanew = int.from_bytes(dos[0x3C:0x40], "little")
+                with open(git_shim, "rb") as f:
+                    f.seek(e_lfanew)
+                    pe_sig = f.read(4)
+                if pe_sig != b"PE\x00\x00":
+                    errors.append(
+                        f"git/cmd/git.exe has bad PE signature at 0x{e_lfanew:X}: "
+                        f"{pe_sig!r}"
+                    )
+            # Shim must be tiny — anything above ~200 KB means MinGit
+            # crept back in.
+            size = git_shim.stat().st_size
+            if size > 256 * 1024:
+                errors.append(
+                    f"git/cmd/git.exe is too large ({size} bytes); "
+                    f"expected <256 KB for the shim"
+                )
     elif platform.startswith("darwin"):
         if not (bundle_root / "lean" / "lib" / "lean" / "libleanshared.dylib").is_file():
             errors.append("Missing critical dylib: lean/lib/lean/libleanshared.dylib")


### PR DESCRIPTION
## Summary

Replace the ~46 MB MinGit install in the Windows bundle with a ~30 KB C
shim (`shim/git_shim.c`) that answers exactly the probes both the lean4
VS Code extension and VS Code's built-in git extension make at startup.

- `git --version` → `git version 2.47.0` (exit 0)
- `git rev-parse ...` → `fatal: not a git repository` (exit 128)
- everything else → same "not a git repository" shape

## Discovery

I audited the lean4 extension v0.0.229 source (`checkGitAvailable` in
`src/diagnostics/setupDiagnoser.ts`) and the VS Code built-in git
extension (`findGit` in `extensions/git/src/git.ts` plus the workspace
scanner in `src/model.ts`). The full report is summarised in the commit
message. Key findings:

- The lean4 extension only checks `exitCode === 0` for `git --version`.
  It doesn't parse stdout.
- VS Code's built-in git extension *does* parse the version string and
  pops a modal warning if the major version is < 2 or equals 2.25.x /
  2.26.x on Windows. The shim reports 2.47.0 to stay clear.
- At workspace activation, the git extension calls
  `git rev-parse --show-toplevel` on each workspace folder and its
  direct subfolders. It expects non-zero exit + stderr matching
  `/Not a git repository/i` so the folder is silently treated as non-
  git. The shim returns exit 128 with that exact phrase.
- Lake's own optional git probes (`captureProc?`, `testProc`) wrap
  non-zero exits and ignore them, so unhandled subcommands are safe.

## Implementation

- `shim/git_shim.c` — the C source (~100 lines). Scans `argv` to skip
  top-level flags (`-C <dir>`, `-c key=val`, `--git-dir`, `--work-tree`,
  `--namespace`) so they're not mistaken for the subcommand. Handles
  `git --version`, `git -v`, `git version`; everything else returns
  the not-a-repo error.
- `download.build_git_shim` cross-compiles the shim at bundle-build
  time. Preference order: `x86_64-w64-mingw32-gcc` → `zig cc -target
  x86_64-windows-gnu` → native `gcc`/`clang` (only when the build host
  is Windows; otherwise refused to avoid silently producing a Mach-O
  or ELF file named `git.exe`).
- The build output is validated via a real PE32+ sanity check (DOS
  `MZ` header **plus** `PE\0\0` signature at `e_lfanew`) before being
  handed to `assemble.py`.
- CI: the `build-windows` job now installs `gcc-mingw-w64-x86-64`.
- `assemble.py` installs the shim at `git/cmd/git.exe`, matching the
  old MinGit layout so `start_lean.cmd`'s existing `%BUNDLE_ROOT%\git\cmd`
  PATH prefix continues to work unchanged.

## Tests

- New `tests/test_git_shim.py` (24 cases):
  - `git --version`, `git -v`, `git version` all return 0 with a
    version string parseable as `>= 2.0.0` and not `2.25/2.26`.
  - `git rev-parse --show-toplevel` returns exit 128 with stderr
    matching the VS Code git-error regex.
  - `git -C <dir>`, `git -c k=v` are parsed correctly.
  - Bare `git`, dangling `-C` with no following arg don't crash.
  - 10 parametrised "unknown subcommand" cases (`status`, `clone`,
    `fetch`, `checkout`, `diff`, …) all exit 128.
  - `build_git_shim` returns `None` on non-Windows, raises when no
    cross-compiler is available on a non-Windows host, and the PE
    signature check catches a native compiler's output.
- `tests/verify_bundle.py` Tier 1: new check that
  `git/cmd/git.exe` is a real PE32+ image (MZ + PE signature at
  `e_lfanew`) and is below 256 KB.
- `tests/test_git_shim.py::test_native_non_windows_compiler_is_rejected`
  monkeypatches the compiler selector to confirm the validation bites.

Tier 5/6 Playwright runs on Windows CI exercise the shim end-to-end by
launching the real bundle through the launcher script.

## Notes / follow-ups

- `PLAN.md` updated: the "extension git check suppression" upstream
  item now notes that even if the lean4 extension stops probing git,
  VS Code's built-in git extension still does, so the shim (or an
  explicit `"git.enabled": false` in `settings.json`) is still needed.
- README "Known issues" updated to describe the shim instead of MinGit.

Closes #18.

## Test plan

- [x] `pytest tests/` passes locally (macOS, Python 3.14): 44 passed,
      16 Windows-specific skipped
- [x] `build_git_shim` refuses to produce a non-PE binary on macOS
      (tested)
- [ ] CI: Tier 1 verify, Tier 2/3 lake+LSP, Tier 5 VSCodium integration
      smoke test, Tier 6 Playwright GUI tests all pass on Windows
- [ ] Bundle size is ~46 MB smaller than before on Windows

🤖 Prepared with Claude Code