### PR TITLE
fix: buffer stdin in lake wrapper to avoid seek on pipe

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -143,14 +143,14 @@ REAL="$(dirname "$0")/lake.real"
 if [ "$1" = "setup-file" ]; then
     "$REAL" "$@" | python3 -c "
 import sys, json
+raw = sys.stdin.buffer.read()
 try:
-    data = json.load(sys.stdin)
+    data = json.loads(raw)
     for arts in data.get('importArts', {}).values():
         arts[:] = [a for a in arts if not a.endswith('.ir')]
     json.dump(data, sys.stdout)
 except Exception:
-    sys.stdin.seek(0)
-    sys.stdout.write(sys.stdin.read())
+    sys.stdout.buffer.write(raw)
 "
 else
     exec "$REAL" "$@"

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -75,6 +75,67 @@ def test_install_lake_wrapper_strips_ir(tmp_path: Path) -> None:
     assert "lake.real" in wrapper_text
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix wrapper only")
+class TestLakeWrapperIntegration:
+    """Integration tests that install the wrapper and run it end-to-end."""
+
+    @staticmethod
+    def _make_fake_lake(lake_bin: Path, output: str) -> None:
+        """Create a fake lake.real that echoes *output* for ``setup-file``."""
+        lake_bin.mkdir(parents=True)
+        # The wrapper renames lake → lake.real, so we write lake first.
+        script = "#!/bin/sh\n" + f'printf %s \'{output}\'\n'
+        (lake_bin / "lake").write_text(script)
+        (lake_bin / "lake").chmod(0o755)
+
+    def test_strips_ir_entries(self, tmp_path: Path) -> None:
+        import subprocess
+        bundle_dir = tmp_path / "bundle"
+        lake_bin = bundle_dir / "lean" / "bin"
+        payload = json.dumps({"importArts": {"Foo": ["Foo.olean", "Foo.ir"]}})
+        self._make_fake_lake(lake_bin, payload)
+        install_lake_wrapper(bundle_dir, "linux-x64")
+
+        result = subprocess.run(
+            [str(lake_bin / "lake"), "setup-file", "Foo.lean"],
+            capture_output=True, timeout=5,
+        )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["importArts"]["Foo"] == ["Foo.olean"]
+
+    def test_fallback_passes_through_non_json(self, tmp_path: Path) -> None:
+        import subprocess
+        bundle_dir = tmp_path / "bundle"
+        lake_bin = bundle_dir / "lean" / "bin"
+        non_json = "warning: something\n{not json at all}\n"
+        self._make_fake_lake(lake_bin, non_json)
+        install_lake_wrapper(bundle_dir, "linux-x64")
+
+        result = subprocess.run(
+            [str(lake_bin / "lake"), "setup-file", "Foo.lean"],
+            capture_output=True, timeout=5,
+        )
+        assert result.returncode == 0
+        assert result.stdout.decode() == non_json
+
+    def test_non_setup_file_passes_through(self, tmp_path: Path) -> None:
+        import subprocess
+        bundle_dir = tmp_path / "bundle"
+        lake_bin = bundle_dir / "lean" / "bin"
+        lake_bin.mkdir(parents=True)
+        (lake_bin / "lake").write_text("#!/bin/sh\necho real-lake-output")
+        (lake_bin / "lake").chmod(0o755)
+        install_lake_wrapper(bundle_dir, "linux-x64")
+
+        result = subprocess.run(
+            [str(lake_bin / "lake"), "build"],
+            capture_output=True, timeout=5,
+        )
+        assert result.returncode == 0
+        assert b"real-lake-output" in result.stdout
+
+
 def test_setup_vscodium_portable_uses_vsix_extension_subdir(tmp_path) -> None:
     vscodium_dir = tmp_path / "vscodium"
     vscodium_dir.mkdir()


### PR DESCRIPTION
The lake wrapper's fallback path called `sys.stdin.seek(0)` to re-read
input after a JSON parse failure, but pipes are not seekable — this always
raises `io.UnsupportedOperation`, producing zero output and a non-zero
exit code.

Read all of stdin into a buffer before parsing so the raw data is
available for the fallback passthrough path.

Adds integration tests that install the wrapper and run it end-to-end,
covering both the IR-stripping happy path and the non-JSON fallback.

Closes #22

🤖 Prepared with Claude Code