### PR TITLE
fix: close Command Prompt after launching VSCodium on Windows

### DIFF
--- a/templates/start_lean.cmd
+++ b/templates/start_lean.cmd
@@ -20,6 +20,8 @@ for /d %%P in ("%BUNDLE_ROOT%\project\.lake\packages\*") do (
 )
 
 :: Launch VSCodium with the project folder
-:: Invoke directly (not via `start`) so the process inherits our environment
-:: and the caller can control the child process. Forward extra args via %*.
-"%BUNDLE_ROOT%\vscodium\VSCodium.exe" "%BUNDLE_ROOT%\project" %*
+:: Use `start` so the Command Prompt window closes immediately instead of
+:: staying open for the entire VSCodium session. The empty "" is required
+:: as the window-title argument (otherwise `start` treats the quoted path
+:: as the title). Environment variables set above are inherited by `start`.
+start "" "%BUNDLE_ROOT%\vscodium\VSCodium.exe" "%BUNDLE_ROOT%\project" %*

--- a/tests/gui-playwright/helpers/launch.ts
+++ b/tests/gui-playwright/helpers/launch.ts
@@ -214,8 +214,8 @@ export async function launchVSCodium(options?: {
 export async function closeVSCodium(result: LaunchResult) {
     try { await result.browser.close(); } catch { /* ignore */ }
     try { result.process.kill(); } catch { /* ignore */ }
-    // On Windows the spawned process is cmd.exe, not VSCodium itself.
-    // Killing cmd may not terminate the child, so use taskkill as fallback.
+    // On Windows the launcher uses `start` to detach VSCodium, so cmd.exe
+    // exits immediately. Use taskkill to terminate VSCodium directly.
     if (process.platform === 'win32') {
         try { childProcess.execSync('taskkill /f /im VSCodium.exe 2>nul', { stdio: 'ignore' }); } catch { /* */ }
     }


### PR DESCRIPTION
Use `start` in `Start_Lean.cmd` so the Command Prompt window closes immediately after launching VSCodium, instead of staying open for the entire session.

Previously the script invoked VSCodium synchronously, which kept a black cmd window visible — confusing for students and risky since closing it would terminate VSCodium. `start` detaches VSCodium while still inheriting the environment variables set by the script.

The GUI test infrastructure already uses `taskkill /f /im VSCodium.exe` for cleanup and `waitForCDP` for readiness detection, so it doesn't depend on the launcher process staying alive.

Closes #24

🤖 Prepared with Claude Code