### PR TITLE
fix: handle quoted and guillemet require syntax in lakefile.lean rewriter

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -273,8 +273,13 @@ def _rewrite_lakefile_toml_deps(bundle_project: Path) -> None:
 def _rewrite_lakefile_lean_deps(bundle_project: Path) -> None:
     """Rewrite lakefile.lean git deps to path deps.
 
-    Handles the Lean DSL syntax: ``require foo from git "url" @ "rev"``
-    → ``require foo from ".lake/packages/foo"``
+    Handles all three ``require`` name forms:
+
+    * bare:      ``require foo from git "url" @ "rev"``
+    * quoted:    ``require "foo" from git "url" @ "rev"``
+    * guillemet: ``require «foo-bar» from git "url" @ "rev"``
+
+    Each is rewritten to ``require <name> from ".lake/packages/<name>"``.
     """
     lakefile = bundle_project / "lakefile.lean"
     if not lakefile.is_file():
@@ -283,11 +288,18 @@ def _rewrite_lakefile_lean_deps(bundle_project: Path) -> None:
     import re
     text = lakefile.read_text()
     # Match: require <name> from git "url" [@ "rev"]
-    pattern = r'(require\s+(\w+)\s+)from\s+git\s+"[^"]*"(\s*@\s*"[^"]*")?'
+    # <name> can be: bare word, "quoted", or «guillemet»
+    # Anchored to start-of-line (with optional leading whitespace) to avoid
+    # rewriting commented-out lines or partial identifier matches.
+    pattern = (
+        r'(?m)^(\s*require\s+'
+        r'(?:"([^"]+)"|«([^»]+)»|(\w+))'
+        r'\s+)from\s+git\s+"[^"]*"(\s*@\s*"[^"]*")?'
+    )
 
     def replace_dep(m):
         prefix = m.group(1)
-        name = m.group(2)
+        name = m.group(2) or m.group(3) or m.group(4)
         return f'{prefix}from ".lake/packages/{name}"'
 
     new_text = re.sub(pattern, replace_dep, text)

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -6,7 +6,12 @@ from pathlib import Path
 import json
 import pytest
 
-from assemble import install_lake_wrapper, prune_ir_from_bundle, setup_vscodium_portable
+from assemble import (
+    _rewrite_lakefile_lean_deps,
+    install_lake_wrapper,
+    prune_ir_from_bundle,
+    setup_vscodium_portable,
+)
 
 
 def test_prune_ir_from_bundle_removes_lean_ir_payloads(tmp_path: Path) -> None:
@@ -92,6 +97,64 @@ def test_setup_vscodium_portable_uses_vsix_extension_subdir(tmp_path) -> None:
     ext_dest = vscodium_dir / "data" / "extensions" / extension_dir.name
     assert (ext_dest / "package.json").is_file()
     assert not (ext_dest / "extension" / "package.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Lakefile.lean rewriting: bare, quoted, and guillemet require syntax
+# ---------------------------------------------------------------------------
+
+class TestRewriteLakefileLeanDeps:
+    """Test _rewrite_lakefile_lean_deps handles all require name forms."""
+
+    def test_bare_require(self, tmp_path: Path) -> None:
+        lakefile = tmp_path / "lakefile.lean"
+        lakefile.write_text('require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v1.0"\n')
+        _rewrite_lakefile_lean_deps(tmp_path)
+        assert lakefile.read_text() == 'require mathlib from ".lake/packages/mathlib"\n'
+
+    def test_quoted_require(self, tmp_path: Path) -> None:
+        lakefile = tmp_path / "lakefile.lean"
+        lakefile.write_text('require "mathlib" from git "https://github.com/leanprover-community/mathlib4" @ "v1.0"\n')
+        _rewrite_lakefile_lean_deps(tmp_path)
+        assert lakefile.read_text() == 'require "mathlib" from ".lake/packages/mathlib"\n'
+
+    def test_guillemet_require(self, tmp_path: Path) -> None:
+        lakefile = tmp_path / "lakefile.lean"
+        lakefile.write_text('require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"\n')
+        _rewrite_lakefile_lean_deps(tmp_path)
+        assert lakefile.read_text() == 'require «doc-gen4» from ".lake/packages/doc-gen4"\n'
+
+    def test_no_rev(self, tmp_path: Path) -> None:
+        lakefile = tmp_path / "lakefile.lean"
+        lakefile.write_text('require mathlib from git "https://github.com/leanprover-community/mathlib4"\n')
+        _rewrite_lakefile_lean_deps(tmp_path)
+        assert lakefile.read_text() == 'require mathlib from ".lake/packages/mathlib"\n'
+
+    def test_multiple_deps(self, tmp_path: Path) -> None:
+        lakefile = tmp_path / "lakefile.lean"
+        lakefile.write_text(
+            'require "mathlib" from git "https://github.com/leanprover-community/mathlib4" @ "v1.0"\n'
+            'require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"\n'
+            'require aesop from git "https://github.com/leanprover-community/aesop"\n'
+        )
+        _rewrite_lakefile_lean_deps(tmp_path)
+        expected = (
+            'require "mathlib" from ".lake/packages/mathlib"\n'
+            'require «doc-gen4» from ".lake/packages/doc-gen4"\n'
+            'require aesop from ".lake/packages/aesop"\n'
+        )
+        assert lakefile.read_text() == expected
+
+    def test_commented_out_require_not_rewritten(self, tmp_path: Path) -> None:
+        lakefile = tmp_path / "lakefile.lean"
+        original = '-- require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v1.0"\n'
+        lakefile.write_text(original)
+        _rewrite_lakefile_lean_deps(tmp_path)
+        assert lakefile.read_text() == original
+
+    def test_no_lakefile(self, tmp_path: Path) -> None:
+        """No crash when lakefile.lean doesn't exist."""
+        _rewrite_lakefile_lean_deps(tmp_path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix `_rewrite_lakefile_lean_deps` regex to match all three `require` name forms: bare (`require foo`), quoted (`require "foo"`), and guillemet (`require «foo-bar»`)
- Anchor regex to start-of-line to avoid rewriting commented-out lines
- Add tests for all three forms, multiple deps, no-rev, commented-out lines, and missing lakefile

Closes #25

🤖 Prepared with Claude Code