### PR TITLE
fix: handle scope/branch deps and arbitrary key order in TOML rewriter

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -233,11 +233,16 @@ def _rewrite_lakefile_toml_deps(bundle_project: Path) -> None:
     Lake validates that the lakefile and manifest agree on dependency
     source kinds. If the manifest says path but the lakefile says git,
     Lake considers targets out-of-date and ``--no-build`` fails.
+
+    Handles all dependency forms including ``scope``+``branch`` syntax
+    (no explicit ``git`` key) and arbitrary key ordering within
+    ``[[require]]`` blocks.
     """
     lakefile = bundle_project / "lakefile.toml"
     if not lakefile.is_file():
         return
 
+    import re
     import tomllib
     text = lakefile.read_text()
     try:
@@ -249,23 +254,66 @@ def _rewrite_lakefile_toml_deps(bundle_project: Path) -> None:
     if not requires:
         return
 
-    # For each git require, replace the git line with a path line
+    # Identify deps that need rewriting: any with git or scope keys
+    # (scope implies a git dep resolved by Lake)
+    names_to_rewrite = set()
     for req in requires:
         name = req.get("name", "")
-        if "git" not in req:
-            continue
-        # Replace: git = "..." with path = ".lake/packages/<name>"
-        # Also remove rev = "..." if present
-        import re
-        # Match the [[require]] block for this name and replace git/rev lines
-        pattern = (
-            r'(\[\[require\]\]\s*\n'
-            r'name\s*=\s*"' + re.escape(name) + r'")\s*\n'
-            r'git\s*=\s*"[^"]*"'
-            r'(\s*\nrev\s*=\s*"[^"]*")?'
+        if name and ("git" in req or "scope" in req):
+            names_to_rewrite.add(name)
+
+    if not names_to_rewrite:
+        return
+
+    # Keys to remove from git/scope dep blocks
+    git_keys = {"git", "rev", "scope", "branch"}
+
+    # Find [[require]] block boundaries in the raw text.
+    # A block starts at [[require]] and ends at the next table header or EOF.
+    header_re = re.compile(r"^\s*\[\[?\w", re.MULTILINE)
+    require_re = re.compile(r"^\s*\[\[\s*require\s*\]\]", re.MULTILINE)
+
+    blocks = []
+    for m in require_re.finditer(text):
+        start = m.start()
+        # Find next header after this one
+        end_match = header_re.search(text, m.end())
+        end = end_match.start() if end_match else len(text)
+        blocks.append((start, end))
+
+    # Process blocks in reverse order to preserve character positions
+    for block_start, block_end in reversed(blocks):
+        block_text = text[block_start:block_end]
+
+        # Extract name from this block, skipping comment lines
+        name_match = re.search(
+            r'^(?!\s*#)\s*name\s*=\s*"([^"]*)"', block_text, re.MULTILINE
         )
-        replacement = r'\1\npath = ".lake/packages/' + name + r'"'
-        text = re.sub(pattern, replacement, text)
+        if not name_match or name_match.group(1) not in names_to_rewrite:
+            continue
+
+        name = name_match.group(1)
+
+        # Remove git-related key lines, insert path at the first removal
+        lines = block_text.split("\n")
+        new_lines = []
+        path_added = False
+        for line in lines:
+            stripped = line.strip()
+            is_git_key = any(
+                re.match(rf"{k}\s*=", stripped) for k in git_keys
+            )
+            if is_git_key:
+                if not path_added:
+                    indent = line[: len(line) - len(line.lstrip())]
+                    new_lines.append(
+                        f'{indent}path = ".lake/packages/{name}"'
+                    )
+                    path_added = True
+            else:
+                new_lines.append(line)
+
+        text = text[:block_start] + "\n".join(new_lines) + text[block_end:]
 
     lakefile.write_text(text)
 

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -9,6 +9,7 @@ import pytest
 
 from assemble import (
     _rewrite_lakefile_lean_deps,
+    _rewrite_lakefile_toml_deps,
     install_lake_wrapper,
     prune_ir_from_bundle,
     setup_vscodium_portable,
@@ -228,6 +229,133 @@ class TestRewriteLakefileLeanDeps:
     def test_no_lakefile(self, tmp_path: Path) -> None:
         """No crash when lakefile.lean doesn't exist."""
         _rewrite_lakefile_lean_deps(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Lakefile TOML rewriting (issue #23)
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteLakefileTomlDeps:
+    """Test _rewrite_lakefile_toml_deps handles all dep forms."""
+
+    def test_standard_git_rev(self, tmp_path: Path) -> None:
+        """Standard case: name immediately followed by git + rev."""
+        (tmp_path / "lakefile.toml").write_text(
+            '[[require]]\nname = "mathlib"\n'
+            'git = "https://github.com/leanprover-community/mathlib4"\n'
+            'rev = "main"\n'
+        )
+        _rewrite_lakefile_toml_deps(tmp_path)
+        result = (tmp_path / "lakefile.toml").read_text()
+        assert 'path = ".lake/packages/mathlib"' in result
+        assert "git" not in result
+        assert "rev" not in result
+
+    def test_scope_branch_no_git(self, tmp_path: Path) -> None:
+        """Pattern 1: scope + branch with no explicit git key."""
+        (tmp_path / "lakefile.toml").write_text(
+            '[[require]]\nname = "mathlib"\n'
+            'scope = "leanprover-community"\n'
+            'branch = "master"\n'
+        )
+        _rewrite_lakefile_toml_deps(tmp_path)
+        result = (tmp_path / "lakefile.toml").read_text()
+        assert 'path = ".lake/packages/mathlib"' in result
+        assert "scope" not in result
+        assert "branch" not in result
+
+    def test_git_not_immediately_after_name(self, tmp_path: Path) -> None:
+        """Pattern 2: scope between name and git."""
+        (tmp_path / "lakefile.toml").write_text(
+            '[[require]]\nname = "mathlib"\n'
+            'scope = "leanprover-community"\n'
+            'git = "https://github.com/leanprover-community/mathlib4"\n'
+            'rev = "main"\n'
+        )
+        _rewrite_lakefile_toml_deps(tmp_path)
+        result = (tmp_path / "lakefile.toml").read_text()
+        assert 'path = ".lake/packages/mathlib"' in result
+        assert "git" not in result
+        assert "scope" not in result
+        assert "rev" not in result
+
+    def test_git_before_name(self, tmp_path: Path) -> None:
+        """Pattern 3: git key appears before name."""
+        (tmp_path / "lakefile.toml").write_text(
+            "[[require]]\n"
+            'git = "https://github.com/leanprover-community/mathlib4"\n'
+            'name = "mathlib"\n'
+        )
+        _rewrite_lakefile_toml_deps(tmp_path)
+        result = (tmp_path / "lakefile.toml").read_text()
+        assert 'path = ".lake/packages/mathlib"' in result
+        assert "git" not in result
+
+    def test_multiple_deps(self, tmp_path: Path) -> None:
+        """Multiple deps: one git, one scope+branch, one path (untouched)."""
+        (tmp_path / "lakefile.toml").write_text(
+            '[[require]]\nname = "mathlib"\n'
+            'git = "https://github.com/leanprover-community/mathlib4"\n'
+            'rev = "v4.0.0"\n'
+            "\n"
+            '[[require]]\nname = "aesop"\n'
+            'scope = "leanprover-community"\n'
+            'branch = "master"\n'
+            "\n"
+            '[[require]]\nname = "local_dep"\n'
+            'path = "./my_dep"\n'
+        )
+        _rewrite_lakefile_toml_deps(tmp_path)
+        result = (tmp_path / "lakefile.toml").read_text()
+        assert 'path = ".lake/packages/mathlib"' in result
+        assert 'path = ".lake/packages/aesop"' in result
+        # The local path dep should be unchanged
+        assert 'path = "./my_dep"' in result
+
+    def test_no_lakefile(self, tmp_path: Path) -> None:
+        """No lakefile.toml present — should be a no-op."""
+        _rewrite_lakefile_toml_deps(tmp_path)  # should not raise
+
+    def test_no_require_section(self, tmp_path: Path) -> None:
+        """Lakefile with no [[require]] — should be a no-op."""
+        (tmp_path / "lakefile.toml").write_text('[package]\nname = "foo"\n')
+        _rewrite_lakefile_toml_deps(tmp_path)
+        result = (tmp_path / "lakefile.toml").read_text()
+        assert result == '[package]\nname = "foo"\n'
+
+    def test_comment_before_name(self, tmp_path: Path) -> None:
+        """A commented-out name line should not confuse the name extraction."""
+        (tmp_path / "lakefile.toml").write_text(
+            "[[require]]\n"
+            '# name = "old"\n'
+            'name = "mathlib"\n'
+            'git = "https://github.com/leanprover-community/mathlib4"\n'
+            'rev = "main"\n'
+        )
+        _rewrite_lakefile_toml_deps(tmp_path)
+        result = (tmp_path / "lakefile.toml").read_text()
+        assert 'path = ".lake/packages/mathlib"' in result
+        assert '# name = "old"' in result
+        assert "git" not in result.replace("# name", "")
+
+    def test_preserves_other_content(self, tmp_path: Path) -> None:
+        """Non-require sections and comments are preserved."""
+        (tmp_path / "lakefile.toml").write_text(
+            '[package]\nname = "myproject"\nversion = "0.1"\n\n'
+            "# A dependency\n"
+            '[[require]]\nname = "mathlib"\n'
+            'scope = "leanprover-community"\n'
+            'branch = "master"\n\n'
+            "[leanOptions]\npp.unicode = true\n"
+        )
+        _rewrite_lakefile_toml_deps(tmp_path)
+        result = (tmp_path / "lakefile.toml").read_text()
+        assert 'name = "myproject"' in result
+        assert "version" in result
+        assert "# A dependency" in result
+        assert 'path = ".lake/packages/mathlib"' in result
+        assert "pp.unicode" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes `_rewrite_lakefile_toml_deps` which failed on lakefiles using `scope`+`branch` syntax (no explicit `git` key), non-standard key ordering, or keys between `name` and `git`
- Replaces fragile regex with a block-based approach: parse TOML to identify deps, find `[[require]]` block boundaries in raw text, remove git-related keys and insert `path` within each block
- Handles comments before the `name` key (comment-aware regex)
- Adds 9 test cases covering all three patterns from the issue plus edge cases

## Test plan

- [x] All existing tests still pass (52 passed, 20 skipped)
- [x] New tests cover: standard git+rev, scope+branch, git-not-after-name, git-before-name, multiple deps, no lakefile, no requires, comment-before-name, preserves other content

Closes #23

🤖 Prepared with Claude Code