### PR TITLE
fix: disable workspace trust in bundle-critical settings

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -158,6 +158,7 @@ _BUNDLE_CRITICAL_SETTINGS: dict[str, object] = {
     "update.mode": "none",
     "extensions.autoCheckUpdates": False,
     "telemetry.telemetryLevel": "off",
+    "security.workspace.trust.enabled": False,
 }
 
 

--- a/tests/test_assemble.py
+++ b/tests/test_assemble.py
@@ -360,6 +360,7 @@ class TestPatchWorkspaceSettings:
         assert "lean4.automaticallyBuildDependencies" in _BUNDLE_CRITICAL_SETTINGS
         assert "lean4.alwaysAskBeforeInstallingLeanVersions" in _BUNDLE_CRITICAL_SETTINGS
         assert "lean4.showSetupWarnings" in _BUNDLE_CRITICAL_SETTINGS
+        assert "security.workspace.trust.enabled" in _BUNDLE_CRITICAL_SETTINGS
 
 
 class TestParseJsonc:

--- a/tests/verify_bundle.py
+++ b/tests/verify_bundle.py
@@ -78,6 +78,7 @@ def verify(bundle_root: Path, platform: str = "windows") -> list[str]:
                 "extensions.autoUpdate": False,
                 "telemetry.telemetryLevel": "off",
                 "lean4.automaticallyBuildDependencies": False,
+                "security.workspace.trust.enabled": False,
             }
             for key, expected in expected_keys.items():
                 actual = settings.get(key)
@@ -87,6 +88,28 @@ def verify(bundle_root: Path, platform: str = "windows") -> list[str]:
             errors.append(f"settings.json: invalid JSON: {e}")
     else:
         errors.append("Missing: vscodium/data/user-data/User/settings.json")
+
+    # Workspace settings (project/.vscode/settings.json) — bundle-critical
+    # values must also be present here because workspace settings override
+    # user settings in VS Code.
+    ws_settings_path = bundle_root / "project" / ".vscode" / "settings.json"
+    if ws_settings_path.is_file():
+        try:
+            ws_settings = json.loads(ws_settings_path.read_text())
+            ws_expected = {
+                "security.workspace.trust.enabled": False,
+                "lean4.automaticallyBuildDependencies": False,
+            }
+            for key, expected in ws_expected.items():
+                actual = ws_settings.get(key)
+                if actual != expected:
+                    errors.append(
+                        f"workspace settings.json: {key} = {actual!r}, expected {expected!r}"
+                    )
+        except json.JSONDecodeError as e:
+            errors.append(f"workspace settings.json: invalid JSON: {e}")
+    else:
+        errors.append("Missing: project/.vscode/settings.json")
 
     # --- Platform-specific shared libraries ---
     if is_windows:


### PR DESCRIPTION
This PR adds `security.workspace.trust.enabled: false` to `_BUNDLE_CRITICAL_SETTINGS` in `assemble.py`, ensuring the workspace trust dialog cannot appear even if a project's `.vscode/settings.json` re-enables it. The user-level `templates/settings.json` already had this setting, but VS Code workspace settings take precedence over user settings.

Also adds the setting to `verify_bundle.py`'s user-settings validation and adds new workspace-level settings verification.

Closes #36

## Test plan
- [x] `pytest tests/` passes (89 passed, 20 skipped)
- [ ] CI passes on all platforms

🤖 Prepared with Claude Code