### PR TITLE
fix: strip macOS quarantine attribute in launcher

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -709,7 +709,7 @@ jobs:
       # --- Tier 0: Student experience (no fixups) ---
       # These checks run with zero CI workarounds — the bundle must work
       # as-is after extraction, exactly as a student would experience it.
-      # The launcher's own xattr -cr handles quarantine; create_zip's
+      # The launcher's own xattr -dr handles quarantine; create_zip's
       # timestamp advance handles olean freshness.  If these fail, the
       # bundle is broken for students regardless of what later tiers say.
 
@@ -776,13 +776,12 @@ jobs:
       - name: "Tier 0: Launcher runs lean (quarantine cleared by script)"
         run: |
           root="${{ steps.find-root.outputs.BUNDLE_ROOT }}"
-          # Source the launcher's environment setup (skip the exec VSCodium)
-          # by running the script up to the xattr -cr and lean/bin setup.
+          # Replicate the launcher's environment setup (skip the exec VSCodium).
+          # The launcher runs xattr -dr first, then sets PATH/ELAN_HOME.
           export BUNDLE_ROOT="$root"
+          xattr -dr com.apple.quarantine "$root" 2>/dev/null || true
           export PATH="$root/lean/bin:$PATH"
           export ELAN_HOME="$root/lean"
-          # The launcher would run xattr -cr; do it here as the launcher would
-          xattr -cr "$root" 2>/dev/null || true
           "$root/lean/bin/lean" --version
 
       # --- Tier 1: Structural integrity ---
@@ -900,7 +899,7 @@ jobs:
           echo "BUNDLE_ROOT=$(pwd)/$root" >> "$GITHUB_OUTPUT"
           echo "Bundle root: $(pwd)/$root"
 
-      # No xattr -cr or touch *.olean here — the bundle itself handles
+      # No xattr -dr or touch *.olean here — the bundle itself handles
       # quarantine (via the launcher) and timestamps (via create_zip).
       # The Tier 6 screenshots must reflect the real student experience.
 
@@ -908,7 +907,7 @@ jobs:
         run: |
           root="${{ steps.find-root.outputs.BUNDLE_ROOT }}"
           export BUNDLE_ROOT="$root"
-          xattr -cr "$root" 2>/dev/null || true
+          xattr -dr com.apple.quarantine "$root" 2>/dev/null || true
 
       - name: "Tier 6: Install Playwright test deps"
         run: |

--- a/templates/start_lean.sh
+++ b/templates/start_lean.sh
@@ -3,6 +3,11 @@
 
 BUNDLE_ROOT="$(cd "$(dirname "$0")" && pwd)"
 
+# Strip macOS quarantine attribute from all bundle files.
+# Without this, Gatekeeper may block lean/lake binaries extracted
+# from a downloaded zip, causing silent LSP startup failure.
+xattr -dr com.apple.quarantine "$BUNDLE_ROOT" 2>/dev/null || true
+
 # Add lean to PATH
 export PATH="$BUNDLE_ROOT/lean/bin:$PATH"
 


### PR DESCRIPTION
This PR adds a quarantine-stripping step to the macOS launcher script, fixing silent LSP startup failures on macOS Ventura+.

- The `lean` and `lake` binaries in official releases have ad-hoc code signatures. When a student downloads and extracts the bundle zip, macOS propagates the `com.apple.quarantine` extended attribute to all files. Gatekeeper then blocks execution of the ad-hoc-signed binaries — but the block happens when the lean4 extension spawns `lean --server`, not at a point where the student sees a dialog, so the failure is silent.
- The fix adds `xattr -dr com.apple.quarantine "$BUNDLE_ROOT"` to the launcher script, running before any bundled binary is executed. Uses `-dr` (delete recursive) targeting only the quarantine attribute rather than `-cr` (clear all) to preserve other extended attributes like Finder tags.
- CI workflow comments updated to match the new launcher behavior.

Closes #39

🤖 Prepared with Claude Code