### PR TITLE
ci: add gate job requiring all CI to pass

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -976,3 +976,26 @@ jobs:
           name: tier6-screenshots-windows
           path: tests/gui-playwright/test-results/
           retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Gate job — require this in branch protection so all CI must pass to merge.
+  # ---------------------------------------------------------------------------
+  ci:
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - unit-tests
+      - test-linux-offline
+      - test-linux-gui
+      - test-linux-arm64-offline
+      - test-linux-arm64-gui
+      - test-windows
+      - test-macos
+      - test-macos-gui
+      - test-windows-gui
+    steps:
+      - name: Check all jobs passed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "::error::Some required jobs did not succeed: ${{ join(needs.*.result, ', ') }}"
+          exit 1


### PR DESCRIPTION
Add a `ci` gate job that depends on every test job (unit-tests, all platform test/offline/GUI jobs). This single job should be configured as the required status check in branch protection on `main`.

Currently `main` has no branch protection rules, so PRs can auto-merge as soon as any subset of jobs passes. After this merges, enable branch protection requiring the `ci` check.

🤖 Prepared with Claude Code